### PR TITLE
Update of gsmlb_minimal.ttl to use opengis.net namespaces as per OGC-NA policy

### DIFF
--- a/ontology/minimal/gsmlb_minimal.ttl
+++ b/ontology/minimal/gsmlb_minimal.ttl
@@ -1,15 +1,15 @@
-@prefix : <http://www.opengis.net/def/gsml/4.1/borehole#> .
+@prefix : <https://www.opengis.net/def/gsml/4.1/borehole#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix gsmlb: <http://www.opengis.net/def/gsml/4.1/borehole#> .
+@prefix gsmlb: <https://www.opengis.net/def/gsml/4.1/borehole#> .
 @prefix iso19150-2: <http://def.isotc211.org/iso19150-2/2012/base#> .
-@base <http://www.opengis.net/def/gsml/4.1/borehole> .
+@base <https://www.opengis.net/def/gsml/4.1/borehole> .
 
-<http://www.opengis.net/def/gsml/4.1/borehole> rdf:type owl:Ontology ;
+<https://www.opengis.net/def/gsml/4.1/borehole> rdf:type owl:Ontology ;
                                  skos:definition "A package of classes representing fundamental geological features (units, structures, and events), earth materials, and the relations between them."@en ,
                                                  "The GeoSciML Borehole package contains model elements for representing Boreholes. This is primarily through re-use of standard components from the (external) Observations and Measurements package."@en .
 
@@ -25,67 +25,67 @@ skos:definition rdf:type owl:AnnotationProperty .
 #    Object Properties
 #################################################################
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#composition
+###  https://www.opengis.net/def/gsml/4.1/borehole#composition
 gsmlb:composition rdf:type owl:ObjectProperty ;
                   skos:definition "Describes the composition (detailed, instance specific, lithologic description) of the GeologicUnit"@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#downholeDrillingDetails
+###  https://www.opengis.net/def/gsml/4.1/borehole#downholeDrillingDetails
 gsmlb:downholeDrillingDetails rdf:type owl:ObjectProperty ;
                               skos:definition "Specifies the drilling method and borehole diameter for intervals down the borehole"@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#geologicHistory
+###  https://www.opengis.net/def/gsml/4.1/borehole#geologicHistory
 gsmlb:geologicHistory rdf:type owl:ObjectProperty ;
                       skos:definition "Relates one or more GeologicEvents to a GeologicFeature to describe their age or geologic history"@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#hierarchyLink
+###  https://www.opengis.net/def/gsml/4.1/borehole#hierarchyLink
 gsmlb:hierarchyLink rdf:type owl:ObjectProperty ;
                     skos:definition "indicates a subsiduary unit with its role and proportion with respect to the container unit"@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#indexData
+###  https://www.opengis.net/def/gsml/4.1/borehole#indexData
 gsmlb:indexData rdf:type owl:ObjectProperty ;
                 skos:definition "Specifies the Borehole details"@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#logElement
+###  https://www.opengis.net/def/gsml/4.1/borehole#logElement
 gsmlb:logElement rdf:type owl:ObjectProperty ;
                  skos:definition "Links to 1-D MappedFeature instances that are logged (interpreted) intervals within a borehole. This requirement is common in geoscience boreholes"@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#numericAge
+###  https://www.opengis.net/def/gsml/4.1/borehole#numericAge
 gsmlb:numericAge rdf:type owl:ObjectProperty ;
                  skos:definition "use of GSML_QuantityRange is recommended to have explicit upper and lower values"@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#occurrence
+###  https://www.opengis.net/def/gsml/4.1/borehole#occurrence
 gsmlb:occurrence rdf:type owl:ObjectProperty ;
                  skos:definition "A description association that links a notional geologic feature with any number of mapped features.  A geologic feature, such as a geologic unit may be linked to mapped features from a number of different maps."@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#parentBorehole
+###  https://www.opengis.net/def/gsml/4.1/borehole#parentBorehole
 gsmlb:parentBorehole rdf:type owl:ObjectProperty ;
                      skos:definition "The borehole in which the interval occurs."@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#referenceLocation
+###  https://www.opengis.net/def/gsml/4.1/borehole#referenceLocation
 gsmlb:referenceLocation rdf:type owl:ObjectProperty ;
                         skos:definition "A Borehole OriginPosition is a feature corresponding to the start point of a borehole log.  This may, but not necessarily, correspond to the borehole collar location (eg, kelly bush)."@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#relatedBorehole
+###  https://www.opengis.net/def/gsml/4.1/borehole#relatedBorehole
 gsmlb:relatedBorehole rdf:type owl:ObjectProperty ;
                       skos:definition "The hole that has this collar for its start point"@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#relatedFeature
+###  https://www.opengis.net/def/gsml/4.1/borehole#relatedFeature
 gsmlb:relatedFeature rdf:type owl:ObjectProperty ;
                      skos:definition "General structure used to define relationships between any feature or object within GeoSciML. Relationships are always binary and directional.  There is always a single source and a single target.  The relationship is always defined from the perspective of the Source and is generally an active verb"@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#targetUnit
+###  https://www.opengis.net/def/gsml/4.1/borehole#targetUnit
 gsmlb:targetUnit rdf:type owl:ObjectProperty ;
                  skos:definition "Indicates the parent unit that contains the GeologicUnitPart."@en .
 
@@ -94,41 +94,41 @@ gsmlb:targetUnit rdf:type owl:ObjectProperty ;
 #    Classes
 #################################################################
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#AnthropogenicGeomorphologicFeature
+###  https://www.opengis.net/def/gsml/4.1/borehole#AnthropogenicGeomorphologicFeature
 gsmlb:AnthropogenicGeomorphologicFeature rdf:type owl:Class ;
                                          rdfs:subClassOf gsmlb:GeomorphologicFeature ;
                                          skos:definition "A geomorphologic feature (ie, landform) which has been created by human activity. For example, dredged channel, midden, open pit, reclaimed land."@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#Borehole
+###  https://www.opengis.net/def/gsml/4.1/borehole#Borehole
 gsmlb:Borehole rdf:type owl:Class ;
                skos:definition "A borehole is the generalized term for any narrow shaft drilled in the ground, either vertically, horizontally, or inclined."@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#BoreholeDetails
+###  https://www.opengis.net/def/gsml/4.1/borehole#BoreholeDetails
 gsmlb:BoreholeDetails rdf:type owl:Class ;
                       skos:definition "Borehole specific index (or metadata) information"@en ,
                                       "Borehole-specific index or header information. This data does not relate to downhole intervals."@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#BoreholeInterval
+###  https://www.opengis.net/def/gsml/4.1/borehole#BoreholeInterval
 gsmlb:BoreholeInterval rdf:type owl:Class ;
                        skos:definition "A special kind of Mapped Feature whose shape is 1-D interval and uses the SRS of the containing borehole"@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#CompositionPart
+###  https://www.opengis.net/def/gsml/4.1/borehole#CompositionPart
 gsmlb:CompositionPart rdf:type owl:Class ;
                       skos:definition "Element to represent composition of a geologic unit in terms of earth material constituents."@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#CompoundMaterial
+###  https://www.opengis.net/def/gsml/4.1/borehole#CompoundMaterial
 gsmlb:CompoundMaterial rdf:type owl:Class ;
                        rdfs:subClassOf gsmlb:EarthMaterial ;
                        skos:definition """An EarthMaterial composed of particles composed of EarthMaterials, possibly including other CompoundMaterials.
 This class is provided primarily as an extensibility point for related domain models that wish to import and build on GeoSciML, and wish to define material types that are compound but are not rock or rock-like material. For most users of GeoSciML \"RockMaterial\" should be used."""@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#Contact
+###  https://www.opengis.net/def/gsml/4.1/borehole#Contact
 gsmlb:Contact rdf:type owl:Class ;
               rdfs:subClassOf gsmlb:GeologicStructure ;
               skos:definition """Very general concept representing any kind of surface separating two geologic units including primary boundaries such as depositional contacts, all kinds of unconformities, intrusive contacts, and gradational contacts, as well as faults that separate geologic units.
@@ -136,41 +136,41 @@ gsmlb:Contact rdf:type owl:Class ;
 Bedding measured as discrete surfaces in the case that those are the feature of interest (e.g. individual cross set surfaces for paleocurrent analysis) should be represented here."""@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#DrillingDetails
+###  https://www.opengis.net/def/gsml/4.1/borehole#DrillingDetails
 gsmlb:DrillingDetails rdf:type owl:Class ;
                       skos:definition "A class to capture description of drilling methods and hole diameter down the hole."@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#EarthMaterial
+###  https://www.opengis.net/def/gsml/4.1/borehole#EarthMaterial
 gsmlb:EarthMaterial rdf:type owl:Class ;
                     skos:definition "The Earth Material class holds a description of a naturally occurring substance in the Earth.  Earth Material represents material composition or substance, and is thus independent of quantity or location. Ideally, Earth Materials are defined strictly based on physical properties, but because of standard geological usage, genetic interpretations may enter into the description as well."@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#Fold
+###  https://www.opengis.net/def/gsml/4.1/borehole#Fold
 gsmlb:Fold rdf:type owl:Class ;
            rdfs:subClassOf gsmlb:GeologicStructure ;
            skos:definition "One or more systematically curved layers, surfaces, or lines in a rock body. Fold denotes a structure formed by the deformation of a GeologicStructure to form a structure that may be described by the translation of an abstract line (the fold axis) parallel to itself along some curvilinear path (the fold profile). Folds have a hinge zone (zone of maximum curvature along the surface) and limbs (parts of the deformed surface not in the hinge zone).  Folds are described by an axial surface, hinge line , profile geometry, the solid angle between the limbs, and the relationships between adjacent folded surfaces if the folded structure is a Layering fabric (similar, parallel)."@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#Foliation
+###  https://www.opengis.net/def/gsml/4.1/borehole#Foliation
 gsmlb:Foliation rdf:type owl:Class ;
                 rdfs:subClassOf gsmlb:GeologicStructure ;
                 skos:definition """A planar arrangement of textural or structural features in any type of rock.  Includes any of a wide variety of penetrative planar geological structures that may be present in a rock.  Examples include schistosity, mylonitic foliation, penetrative bedding structure (lamination), and cleavage.  Following the proposed definition of gneiss by the NADM Science Language Technical Team, penetrative planar foliation defined by layers > 5 mm thick is considered Layering.
 Bedding as a fabric representing the average orientation of paleodepositional surface should be encoded through the foliationType; might apply to bedding that is layering or a foliation without layering (e.g. clast alignment in amalgamated beds)."""@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#GSML
+###  https://www.opengis.net/def/gsml/4.1/borehole#GSML
 gsmlb:GSML rdf:type owl:Class ;
            skos:definition "A collection container for items to be bundled in WFS response documents and other applications. FeatureType stereotype allows this to be a FeatureMember in a WFS_FeatureCollection."@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#GeologicEvent
+###  https://www.opengis.net/def/gsml/4.1/borehole#GeologicEvent
 gsmlb:GeologicEvent rdf:type owl:Class ;
                     rdfs:subClassOf gsmlb:GeologicFeature ;
                     skos:definition "An identifiable event during which one or more geological processes act to modify geological entities. A GeologicEvent may have a specified geologic age (numeric age or GeochologicEraTerm) and may have specified environments and processes. An example might be a cratonic uplift event during which erosion, sedimentation, and volcanism all take place."@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#GeologicFeature
+###  https://www.opengis.net/def/gsml/4.1/borehole#GeologicFeature
 gsmlb:GeologicFeature rdf:type owl:Class ;
                       skos:definition """The abstract GeologicFeature class represents a conceptual feature that is hypothesized to exist coherently in the world.
    * this corresponds with a \"legend item\" from a traditional geologic map
@@ -181,7 +181,7 @@ The implemented Geologic Feature instance acts as the \"description package\"
     * the description package is classified according to its purpose as an Instance, TypicalNorm, or DefiningNorm."""@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#GeologicStructure
+###  https://www.opengis.net/def/gsml/4.1/borehole#GeologicStructure
 gsmlb:GeologicStructure rdf:type owl:Class ;
                         rdfs:subClassOf gsmlb:GeologicFeature ;
                         skos:definition """A configuration of matter in the Earth based on describable inhomogeneity, pattern, or fracture in an EarthMaterial.
@@ -191,7 +191,7 @@ because they depend on the configuration of parts of a rock body. Includes sedim
 The general GeologicRelation is used to associate penetrative GeologicStructures with GeologicUnits."""@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#GeologicUnit
+###  https://www.opengis.net/def/gsml/4.1/borehole#GeologicUnit
 gsmlb:GeologicUnit rdf:type owl:Class ;
                    rdfs:subClassOf gsmlb:GeologicFeature ;
                    skos:definition """Operationally, the GeologicUnit element is a container used to associate geologic properties with some mapped occurrence (through GeologicFeature.occurrence -> MappedFeature link), or with a geologic unit ControlledConcept in a vocabulary (through the GeologicUnit.classifier ->ControlledConcept link).
@@ -201,18 +201,18 @@ Conceptually, may represent a body of material in the Earth whose complete and p
 Spatial properties are only available through association with a MappedFeature. Includes both formal units (i.e. formally adopted and named in the official lexicon) and informal units (i.e. named but not promoted to the lexicon) and unnamed units (i.e. recognisable and described and delineable in the field but not otherwise formalised)."""@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#GeologicUnitHierarchy
+###  https://www.opengis.net/def/gsml/4.1/borehole#GeologicUnitHierarchy
 gsmlb:GeologicUnitHierarchy rdf:type owl:Class ;
                             skos:definition "GeologicUnitHierarchy associates a GeologicUnit with another GeologicUnit that is a proper part of that unit. Parts may be formal or notional. Formal parts refer to a specific body of rock, as in formal stratigraphic members. Notional parts refer to assemblages of particular EarthMaterials with particular internal structure, which may be repeated in various places within a unit (e.g. 'turbidite sequence', 'point bar assemblage', 'leucosome veins')"@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#GeomorphologicFeature
+###  https://www.opengis.net/def/gsml/4.1/borehole#GeomorphologicFeature
 gsmlb:GeomorphologicFeature rdf:type owl:Class ;
                             rdfs:subClassOf gsmlb:GeologicFeature ;
                             skos:definition "A feature describing the shape and nature of the Earth's land surface (ie, a landform).  These landforms may be created by natural Earth processes (eg, river channel, beach, moraine, mountain) or through human (anthropogenic) activity (eg, dredged channel, reclaimed land, mine waste dumps)."@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#MappedFeature
+###  https://www.opengis.net/def/gsml/4.1/borehole#MappedFeature
 gsmlb:MappedFeature rdf:type owl:Class ;
                     skos:definition """A MappedFeature is part of a geological interpretation.
 It provides a link between a notional feature (description package) and one spatial representation of it, or part of it. (Exposures, Surface Traces and Intercepts, etc)
@@ -224,23 +224,23 @@ It provides a link between a notional feature (description package) and one spat
 A Mapped Feature is always associated with some sampling feature - e.g. a mapping surface, a section, a Borehole (see BoreHolesAndObservation) etc. As noted on the diagram, if the associated sampling feature is a Borehole, then the shape associated with the MappedFeature will usually be either a point or an interval. This reconciles the 2-D (\"map\", section) and 1-D (borehole, traverse) viewpoints in a common abstraction."""@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#MappedInterval
+###  https://www.opengis.net/def/gsml/4.1/borehole#MappedInterval
 gsmlb:MappedInterval rdf:type owl:Class ;
                      skos:definition "A special kind of Mapped Feature whose shape is 1-D interval and uses the SRS of the containing borehole"@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#NaturalGeomorphologicFeature
+###  https://www.opengis.net/def/gsml/4.1/borehole#NaturalGeomorphologicFeature
 gsmlb:NaturalGeomorphologicFeature rdf:type owl:Class ;
                                    rdfs:subClassOf gsmlb:GeomorphologicFeature ;
                                    skos:definition "A geomorphologic feature (ie, landform) that has been created by natural Earth processes. For example, river channel, beach ridge, caldera, canyon, moraine, mud flat."@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#NumericAgeRange
+###  https://www.opengis.net/def/gsml/4.1/borehole#NumericAgeRange
 gsmlb:NumericAgeRange rdf:type owl:Class ;
                       skos:definition "Class to represent general age assignment using numeric measurement results. All attributes have cardinality 1; report with nilReason=\"missing\" if a value is absent."@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#OriginPosition
+###  https://www.opengis.net/def/gsml/4.1/borehole#OriginPosition
 gsmlb:OriginPosition rdf:type owl:Class ;
                      skos:definition """A Borehole OriginPosition is a feature corresponding to the start point of a borehole log.  This may, but not necessarily, correspond to the borehole collar location (eg, kelly bush).
 
@@ -251,13 +251,13 @@ Implementers delivering 3-D origin locations should provide an elevation to impr
 In situations where the origin position changes over the life of the borehole (eg, due to subsidence or destruction of the original collar), the origin position should be updated to the new location."""@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#RockMaterial
+###  https://www.opengis.net/def/gsml/4.1/borehole#RockMaterial
 gsmlb:RockMaterial rdf:type owl:Class ;
                    rdfs:subClassOf gsmlb:CompoundMaterial ;
                    skos:definition "A specialized CompoundMaterial that includes consolidated and unconsolidated materials as well as mixtures of consolidated and unconsolidated materials."@en .
 
 
-###  http://www.opengis.net/def/gsml/4.1/borehole#ShearDisplacementStructure
+###  https://www.opengis.net/def/gsml/4.1/borehole#ShearDisplacementStructure
 gsmlb:ShearDisplacementStructure rdf:type owl:Class ;
                                  rdfs:subClassOf gsmlb:GeologicStructure ;
                                  skos:definition "A shear displacement structure includes all brittle to ductile style structures along which displacement has occurred, from a simple, single 'planar' brittle or ductile surface to a fault system comprised of 10's of strands of both brittle and ductile nature. This structure may have some significant thickness (a deformation zone) and have an associated body of deformed rock that may be considered a DeformationUnit"@en .

--- a/ontology/minimal/gsmlb_minimal.ttl
+++ b/ontology/minimal/gsmlb_minimal.ttl
@@ -1,15 +1,15 @@
-@prefix : <http://geosciml.org/def/gsmlb#> .
+@prefix : <http://www.opengis.net/def/gsml/4.1/borehole#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix gsmlb: <http://geosciml.org/def/gsmlb#> .
+@prefix gsmlb: <http://www.opengis.net/def/gsml/4.1/borehole#> .
 @prefix iso19150-2: <http://def.isotc211.org/iso19150-2/2012/base#> .
-@base <http://geosciml.org/def/gsmlb> .
+@base <http://www.opengis.net/def/gsml/4.1/borehole> .
 
-<http://geosciml.org/def/gsmlb> rdf:type owl:Ontology ;
+<http://www.opengis.net/def/gsml/4.1/borehole> rdf:type owl:Ontology ;
                                  skos:definition "A package of classes representing fundamental geological features (units, structures, and events), earth materials, and the relations between them."@en ,
                                                  "The GeoSciML Borehole package contains model elements for representing Boreholes. This is primarily through re-use of standard components from the (external) Observations and Measurements package."@en .
 
@@ -25,67 +25,67 @@ skos:definition rdf:type owl:AnnotationProperty .
 #    Object Properties
 #################################################################
 
-###  http://geosciml.org/def/gsmlb#composition
+###  http://www.opengis.net/def/gsml/4.1/borehole#composition
 gsmlb:composition rdf:type owl:ObjectProperty ;
                   skos:definition "Describes the composition (detailed, instance specific, lithologic description) of the GeologicUnit"@en .
 
 
-###  http://geosciml.org/def/gsmlb#downholeDrillingDetails
+###  http://www.opengis.net/def/gsml/4.1/borehole#downholeDrillingDetails
 gsmlb:downholeDrillingDetails rdf:type owl:ObjectProperty ;
                               skos:definition "Specifies the drilling method and borehole diameter for intervals down the borehole"@en .
 
 
-###  http://geosciml.org/def/gsmlb#geologicHistory
+###  http://www.opengis.net/def/gsml/4.1/borehole#geologicHistory
 gsmlb:geologicHistory rdf:type owl:ObjectProperty ;
                       skos:definition "Relates one or more GeologicEvents to a GeologicFeature to describe their age or geologic history"@en .
 
 
-###  http://geosciml.org/def/gsmlb#hierarchyLink
+###  http://www.opengis.net/def/gsml/4.1/borehole#hierarchyLink
 gsmlb:hierarchyLink rdf:type owl:ObjectProperty ;
                     skos:definition "indicates a subsiduary unit with its role and proportion with respect to the container unit"@en .
 
 
-###  http://geosciml.org/def/gsmlb#indexData
+###  http://www.opengis.net/def/gsml/4.1/borehole#indexData
 gsmlb:indexData rdf:type owl:ObjectProperty ;
                 skos:definition "Specifies the Borehole details"@en .
 
 
-###  http://geosciml.org/def/gsmlb#logElement
+###  http://www.opengis.net/def/gsml/4.1/borehole#logElement
 gsmlb:logElement rdf:type owl:ObjectProperty ;
                  skos:definition "Links to 1-D MappedFeature instances that are logged (interpreted) intervals within a borehole. This requirement is common in geoscience boreholes"@en .
 
 
-###  http://geosciml.org/def/gsmlb#numericAge
+###  http://www.opengis.net/def/gsml/4.1/borehole#numericAge
 gsmlb:numericAge rdf:type owl:ObjectProperty ;
                  skos:definition "use of GSML_QuantityRange is recommended to have explicit upper and lower values"@en .
 
 
-###  http://geosciml.org/def/gsmlb#occurrence
+###  http://www.opengis.net/def/gsml/4.1/borehole#occurrence
 gsmlb:occurrence rdf:type owl:ObjectProperty ;
                  skos:definition "A description association that links a notional geologic feature with any number of mapped features.  A geologic feature, such as a geologic unit may be linked to mapped features from a number of different maps."@en .
 
 
-###  http://geosciml.org/def/gsmlb#parentBorehole
+###  http://www.opengis.net/def/gsml/4.1/borehole#parentBorehole
 gsmlb:parentBorehole rdf:type owl:ObjectProperty ;
                      skos:definition "The borehole in which the interval occurs."@en .
 
 
-###  http://geosciml.org/def/gsmlb#referenceLocation
+###  http://www.opengis.net/def/gsml/4.1/borehole#referenceLocation
 gsmlb:referenceLocation rdf:type owl:ObjectProperty ;
                         skos:definition "A Borehole OriginPosition is a feature corresponding to the start point of a borehole log.  This may, but not necessarily, correspond to the borehole collar location (eg, kelly bush)."@en .
 
 
-###  http://geosciml.org/def/gsmlb#relatedBorehole
+###  http://www.opengis.net/def/gsml/4.1/borehole#relatedBorehole
 gsmlb:relatedBorehole rdf:type owl:ObjectProperty ;
                       skos:definition "The hole that has this collar for its start point"@en .
 
 
-###  http://geosciml.org/def/gsmlb#relatedFeature
+###  http://www.opengis.net/def/gsml/4.1/borehole#relatedFeature
 gsmlb:relatedFeature rdf:type owl:ObjectProperty ;
                      skos:definition "General structure used to define relationships between any feature or object within GeoSciML. Relationships are always binary and directional.  There is always a single source and a single target.  The relationship is always defined from the perspective of the Source and is generally an active verb"@en .
 
 
-###  http://geosciml.org/def/gsmlb#targetUnit
+###  http://www.opengis.net/def/gsml/4.1/borehole#targetUnit
 gsmlb:targetUnit rdf:type owl:ObjectProperty ;
                  skos:definition "Indicates the parent unit that contains the GeologicUnitPart."@en .
 
@@ -94,41 +94,41 @@ gsmlb:targetUnit rdf:type owl:ObjectProperty ;
 #    Classes
 #################################################################
 
-###  http://geosciml.org/def/gsmlb#AnthropogenicGeomorphologicFeature
+###  http://www.opengis.net/def/gsml/4.1/borehole#AnthropogenicGeomorphologicFeature
 gsmlb:AnthropogenicGeomorphologicFeature rdf:type owl:Class ;
                                          rdfs:subClassOf gsmlb:GeomorphologicFeature ;
                                          skos:definition "A geomorphologic feature (ie, landform) which has been created by human activity. For example, dredged channel, midden, open pit, reclaimed land."@en .
 
 
-###  http://geosciml.org/def/gsmlb#Borehole
+###  http://www.opengis.net/def/gsml/4.1/borehole#Borehole
 gsmlb:Borehole rdf:type owl:Class ;
                skos:definition "A borehole is the generalized term for any narrow shaft drilled in the ground, either vertically, horizontally, or inclined."@en .
 
 
-###  http://geosciml.org/def/gsmlb#BoreholeDetails
+###  http://www.opengis.net/def/gsml/4.1/borehole#BoreholeDetails
 gsmlb:BoreholeDetails rdf:type owl:Class ;
                       skos:definition "Borehole specific index (or metadata) information"@en ,
                                       "Borehole-specific index or header information. This data does not relate to downhole intervals."@en .
 
 
-###  http://geosciml.org/def/gsmlb#BoreholeInterval
+###  http://www.opengis.net/def/gsml/4.1/borehole#BoreholeInterval
 gsmlb:BoreholeInterval rdf:type owl:Class ;
                        skos:definition "A special kind of Mapped Feature whose shape is 1-D interval and uses the SRS of the containing borehole"@en .
 
 
-###  http://geosciml.org/def/gsmlb#CompositionPart
+###  http://www.opengis.net/def/gsml/4.1/borehole#CompositionPart
 gsmlb:CompositionPart rdf:type owl:Class ;
                       skos:definition "Element to represent composition of a geologic unit in terms of earth material constituents."@en .
 
 
-###  http://geosciml.org/def/gsmlb#CompoundMaterial
+###  http://www.opengis.net/def/gsml/4.1/borehole#CompoundMaterial
 gsmlb:CompoundMaterial rdf:type owl:Class ;
                        rdfs:subClassOf gsmlb:EarthMaterial ;
-                       skos:definition """An EarthMaterial composed of particles composed of EarthMaterials, possibly including other CompoundMaterials. 
+                       skos:definition """An EarthMaterial composed of particles composed of EarthMaterials, possibly including other CompoundMaterials.
 This class is provided primarily as an extensibility point for related domain models that wish to import and build on GeoSciML, and wish to define material types that are compound but are not rock or rock-like material. For most users of GeoSciML \"RockMaterial\" should be used."""@en .
 
 
-###  http://geosciml.org/def/gsmlb#Contact
+###  http://www.opengis.net/def/gsml/4.1/borehole#Contact
 gsmlb:Contact rdf:type owl:Class ;
               rdfs:subClassOf gsmlb:GeologicStructure ;
               skos:definition """Very general concept representing any kind of surface separating two geologic units including primary boundaries such as depositional contacts, all kinds of unconformities, intrusive contacts, and gradational contacts, as well as faults that separate geologic units.
@@ -136,41 +136,41 @@ gsmlb:Contact rdf:type owl:Class ;
 Bedding measured as discrete surfaces in the case that those are the feature of interest (e.g. individual cross set surfaces for paleocurrent analysis) should be represented here."""@en .
 
 
-###  http://geosciml.org/def/gsmlb#DrillingDetails
+###  http://www.opengis.net/def/gsml/4.1/borehole#DrillingDetails
 gsmlb:DrillingDetails rdf:type owl:Class ;
                       skos:definition "A class to capture description of drilling methods and hole diameter down the hole."@en .
 
 
-###  http://geosciml.org/def/gsmlb#EarthMaterial
+###  http://www.opengis.net/def/gsml/4.1/borehole#EarthMaterial
 gsmlb:EarthMaterial rdf:type owl:Class ;
                     skos:definition "The Earth Material class holds a description of a naturally occurring substance in the Earth.  Earth Material represents material composition or substance, and is thus independent of quantity or location. Ideally, Earth Materials are defined strictly based on physical properties, but because of standard geological usage, genetic interpretations may enter into the description as well."@en .
 
 
-###  http://geosciml.org/def/gsmlb#Fold
+###  http://www.opengis.net/def/gsml/4.1/borehole#Fold
 gsmlb:Fold rdf:type owl:Class ;
            rdfs:subClassOf gsmlb:GeologicStructure ;
            skos:definition "One or more systematically curved layers, surfaces, or lines in a rock body. Fold denotes a structure formed by the deformation of a GeologicStructure to form a structure that may be described by the translation of an abstract line (the fold axis) parallel to itself along some curvilinear path (the fold profile). Folds have a hinge zone (zone of maximum curvature along the surface) and limbs (parts of the deformed surface not in the hinge zone).  Folds are described by an axial surface, hinge line , profile geometry, the solid angle between the limbs, and the relationships between adjacent folded surfaces if the folded structure is a Layering fabric (similar, parallel)."@en .
 
 
-###  http://geosciml.org/def/gsmlb#Foliation
+###  http://www.opengis.net/def/gsml/4.1/borehole#Foliation
 gsmlb:Foliation rdf:type owl:Class ;
                 rdfs:subClassOf gsmlb:GeologicStructure ;
-                skos:definition """A planar arrangement of textural or structural features in any type of rock.  Includes any of a wide variety of penetrative planar geological structures that may be present in a rock.  Examples include schistosity, mylonitic foliation, penetrative bedding structure (lamination), and cleavage.  Following the proposed definition of gneiss by the NADM Science Language Technical Team, penetrative planar foliation defined by layers > 5 mm thick is considered Layering. 
+                skos:definition """A planar arrangement of textural or structural features in any type of rock.  Includes any of a wide variety of penetrative planar geological structures that may be present in a rock.  Examples include schistosity, mylonitic foliation, penetrative bedding structure (lamination), and cleavage.  Following the proposed definition of gneiss by the NADM Science Language Technical Team, penetrative planar foliation defined by layers > 5 mm thick is considered Layering.
 Bedding as a fabric representing the average orientation of paleodepositional surface should be encoded through the foliationType; might apply to bedding that is layering or a foliation without layering (e.g. clast alignment in amalgamated beds)."""@en .
 
 
-###  http://geosciml.org/def/gsmlb#GSML
+###  http://www.opengis.net/def/gsml/4.1/borehole#GSML
 gsmlb:GSML rdf:type owl:Class ;
            skos:definition "A collection container for items to be bundled in WFS response documents and other applications. FeatureType stereotype allows this to be a FeatureMember in a WFS_FeatureCollection."@en .
 
 
-###  http://geosciml.org/def/gsmlb#GeologicEvent
+###  http://www.opengis.net/def/gsml/4.1/borehole#GeologicEvent
 gsmlb:GeologicEvent rdf:type owl:Class ;
                     rdfs:subClassOf gsmlb:GeologicFeature ;
                     skos:definition "An identifiable event during which one or more geological processes act to modify geological entities. A GeologicEvent may have a specified geologic age (numeric age or GeochologicEraTerm) and may have specified environments and processes. An example might be a cratonic uplift event during which erosion, sedimentation, and volcanism all take place."@en .
 
 
-###  http://geosciml.org/def/gsmlb#GeologicFeature
+###  http://www.opengis.net/def/gsml/4.1/borehole#GeologicFeature
 gsmlb:GeologicFeature rdf:type owl:Class ;
                       skos:definition """The abstract GeologicFeature class represents a conceptual feature that is hypothesized to exist coherently in the world.
    * this corresponds with a \"legend item\" from a traditional geologic map
@@ -181,17 +181,17 @@ The implemented Geologic Feature instance acts as the \"description package\"
     * the description package is classified according to its purpose as an Instance, TypicalNorm, or DefiningNorm."""@en .
 
 
-###  http://geosciml.org/def/gsmlb#GeologicStructure
+###  http://www.opengis.net/def/gsml/4.1/borehole#GeologicStructure
 gsmlb:GeologicStructure rdf:type owl:Class ;
                         rdfs:subClassOf gsmlb:GeologicFeature ;
-                        skos:definition """A configuration of matter in the Earth based on describable inhomogeneity, pattern, or fracture in an EarthMaterial. 
-The identity of a GeologicStructure is independent of the material that is the substrate for the structure. 
-Properties like \"clast-supported\",  \"matrix-supported\", and \"graded bed\" that do not involve orientation are considered kinds of GeologicStructure 
+                        skos:definition """A configuration of matter in the Earth based on describable inhomogeneity, pattern, or fracture in an EarthMaterial.
+The identity of a GeologicStructure is independent of the material that is the substrate for the structure.
+Properties like \"clast-supported\",  \"matrix-supported\", and \"graded bed\" that do not involve orientation are considered kinds of GeologicStructure
 because they depend on the configuration of parts of a rock body. Includes sedimentary structures.
 The general GeologicRelation is used to associate penetrative GeologicStructures with GeologicUnits."""@en .
 
 
-###  http://geosciml.org/def/gsmlb#GeologicUnit
+###  http://www.opengis.net/def/gsml/4.1/borehole#GeologicUnit
 gsmlb:GeologicUnit rdf:type owl:Class ;
                    rdfs:subClassOf gsmlb:GeologicFeature ;
                    skos:definition """Operationally, the GeologicUnit element is a container used to associate geologic properties with some mapped occurrence (through GeologicFeature.occurrence -> MappedFeature link), or with a geologic unit ControlledConcept in a vocabulary (through the GeologicUnit.classifier ->ControlledConcept link).
@@ -201,63 +201,63 @@ Conceptually, may represent a body of material in the Earth whose complete and p
 Spatial properties are only available through association with a MappedFeature. Includes both formal units (i.e. formally adopted and named in the official lexicon) and informal units (i.e. named but not promoted to the lexicon) and unnamed units (i.e. recognisable and described and delineable in the field but not otherwise formalised)."""@en .
 
 
-###  http://geosciml.org/def/gsmlb#GeologicUnitHierarchy
+###  http://www.opengis.net/def/gsml/4.1/borehole#GeologicUnitHierarchy
 gsmlb:GeologicUnitHierarchy rdf:type owl:Class ;
                             skos:definition "GeologicUnitHierarchy associates a GeologicUnit with another GeologicUnit that is a proper part of that unit. Parts may be formal or notional. Formal parts refer to a specific body of rock, as in formal stratigraphic members. Notional parts refer to assemblages of particular EarthMaterials with particular internal structure, which may be repeated in various places within a unit (e.g. 'turbidite sequence', 'point bar assemblage', 'leucosome veins')"@en .
 
 
-###  http://geosciml.org/def/gsmlb#GeomorphologicFeature
+###  http://www.opengis.net/def/gsml/4.1/borehole#GeomorphologicFeature
 gsmlb:GeomorphologicFeature rdf:type owl:Class ;
                             rdfs:subClassOf gsmlb:GeologicFeature ;
                             skos:definition "A feature describing the shape and nature of the Earth's land surface (ie, a landform).  These landforms may be created by natural Earth processes (eg, river channel, beach, moraine, mountain) or through human (anthropogenic) activity (eg, dredged channel, reclaimed land, mine waste dumps)."@en .
 
 
-###  http://geosciml.org/def/gsmlb#MappedFeature
+###  http://www.opengis.net/def/gsml/4.1/borehole#MappedFeature
 gsmlb:MappedFeature rdf:type owl:Class ;
-                    skos:definition """A MappedFeature is part of a geological interpretation. 
+                    skos:definition """A MappedFeature is part of a geological interpretation.
 It provides a link between a notional feature (description package) and one spatial representation of it, or part of it. (Exposures, Surface Traces and Intercepts, etc)
     * the specific bounded occurrence, such as an outcrop or map polygon
     * the Mapped Feature carries a geometry or shape
           - the association with a Geologic Feature (legend item) provides specification of all the other descriptors
-          - the association with a Sampling Feature provides the context and dimensionality 
+          - the association with a Sampling Feature provides the context and dimensionality
 
 A Mapped Feature is always associated with some sampling feature - e.g. a mapping surface, a section, a Borehole (see BoreHolesAndObservation) etc. As noted on the diagram, if the associated sampling feature is a Borehole, then the shape associated with the MappedFeature will usually be either a point or an interval. This reconciles the 2-D (\"map\", section) and 1-D (borehole, traverse) viewpoints in a common abstraction."""@en .
 
 
-###  http://geosciml.org/def/gsmlb#MappedInterval
+###  http://www.opengis.net/def/gsml/4.1/borehole#MappedInterval
 gsmlb:MappedInterval rdf:type owl:Class ;
                      skos:definition "A special kind of Mapped Feature whose shape is 1-D interval and uses the SRS of the containing borehole"@en .
 
 
-###  http://geosciml.org/def/gsmlb#NaturalGeomorphologicFeature
+###  http://www.opengis.net/def/gsml/4.1/borehole#NaturalGeomorphologicFeature
 gsmlb:NaturalGeomorphologicFeature rdf:type owl:Class ;
                                    rdfs:subClassOf gsmlb:GeomorphologicFeature ;
                                    skos:definition "A geomorphologic feature (ie, landform) that has been created by natural Earth processes. For example, river channel, beach ridge, caldera, canyon, moraine, mud flat."@en .
 
 
-###  http://geosciml.org/def/gsmlb#NumericAgeRange
+###  http://www.opengis.net/def/gsml/4.1/borehole#NumericAgeRange
 gsmlb:NumericAgeRange rdf:type owl:Class ;
                       skos:definition "Class to represent general age assignment using numeric measurement results. All attributes have cardinality 1; report with nilReason=\"missing\" if a value is absent."@en .
 
 
-###  http://geosciml.org/def/gsmlb#OriginPosition
+###  http://www.opengis.net/def/gsml/4.1/borehole#OriginPosition
 gsmlb:OriginPosition rdf:type owl:Class ;
                      skos:definition """A Borehole OriginPosition is a feature corresponding to the start point of a borehole log.  This may, but not necessarily, correspond to the borehole collar location (eg, kelly bush).
 
 If a text descripiton of the location is available, it should be placed in the gml:description for that feature.  If no GM_Point is available, an OGC nil value should be used.
 
-Implementers delivering 3-D origin locations should provide an elevation to improve interoperability. 
+Implementers delivering 3-D origin locations should provide an elevation to improve interoperability.
 
 In situations where the origin position changes over the life of the borehole (eg, due to subsidence or destruction of the original collar), the origin position should be updated to the new location."""@en .
 
 
-###  http://geosciml.org/def/gsmlb#RockMaterial
+###  http://www.opengis.net/def/gsml/4.1/borehole#RockMaterial
 gsmlb:RockMaterial rdf:type owl:Class ;
                    rdfs:subClassOf gsmlb:CompoundMaterial ;
                    skos:definition "A specialized CompoundMaterial that includes consolidated and unconsolidated materials as well as mixtures of consolidated and unconsolidated materials."@en .
 
 
-###  http://geosciml.org/def/gsmlb#ShearDisplacementStructure
+###  http://www.opengis.net/def/gsml/4.1/borehole#ShearDisplacementStructure
 gsmlb:ShearDisplacementStructure rdf:type owl:Class ;
                                  rdfs:subClassOf gsmlb:GeologicStructure ;
                                  skos:definition "A shear displacement structure includes all brittle to ductile style structures along which displacement has occurred, from a simple, single 'planar' brittle or ductile surface to a fault system comprised of 10's of strands of both brittle and ductile nature. This structure may have some significant thickness (a deformation zone) and have an associated body of deformed rock that may be considered a DeformationUnit"@en .


### PR DESCRIPTION
Replacement of the namespace 'http://geosciml.org/def/gsmlb' with the namespace 'https://www.opengis.net/def/gsml/4.1/borehole'.

This is inline with OGC-NA policy at https://docs.opengeospatial.org/pol/09-048r5.html